### PR TITLE
Update MailHelper.cs

### DIFF
--- a/src/SendGrid/Helpers/Mail/MailHelper.cs
+++ b/src/SendGrid/Helpers/Mail/MailHelper.cs
@@ -17,7 +17,7 @@ namespace SendGrid.Helpers.Mail
         private const string NameGroup = "name";
         private const string EmailGroup = "email";
         private static readonly Regex Rfc2822Regex = new Regex(
-            $@"(?:(?<{NameGroup}>)(?<{EmailGroup}>[^\<]*@.*[^\>])|(?<{NameGroup}>[^\<]*)\<(?<{EmailGroup}>.*@.*)\>)",
+            $@"(?:(?<{NameGroup}>[^\<]*)\<(?<{EmailGroup}>.*@.*)\>|(?<{NameGroup}>)(?<{EmailGroup}>[^\<]*@.*[^\>]))",
             RegexOptions.ECMAScript);
 
         /// <summary>


### PR DESCRIPTION
fix email regex to allow email addresses in the display name.

Input: username@example.com <username@example.com>
Expected:
-NameGroup: username@example.com
-EmailGroup: username@example.com

Initial:
-NameGroup: {empty string}
-EmailGroup: 	username@example.com <username@example.com
Result: A match is found, therefore there is no error caught and email string is bad

After:
-NameGroup: username@example.com
-EmailGroup: username@example.com
Result: Success!

Other test cases:
-<username@example.com> SUCCESS
-username@example.com SUCCESS
-username <username@example.com> SUCCESS
-username <usernameexample.com> NO MATCH (SUCCESS)

